### PR TITLE
Changes to build process (Fixes #6, Fixes #7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if(CMAKE_BUILD_ZLIB)
     message(FATAL_ERROR "Build step for zlib failed: ${result}")
   endif()
   set(ZLIB ${CMAKE_BINARY_DIR}/lib/libz.a)
+  include_directories(${CMAKE_BINARY_DIR}/external/zlib)
 else()
   find_library(ZLIB z PATHS ${CMAKE_SOURCE_DIR}/KMC/kmc_tools/libs)
 endif()
@@ -56,8 +57,9 @@ if(CMAKE_BUILD_BZIP2)
     TEST_COMMAND      ""
     UPDATE_COMMAND    ""
   )
+  include_directories(${CMAKE_BINARY_DIR}/external/bzip2)
 else()
-  find_library(BZIP2 bz2 PATHS ${CMAKE_BINARY_DIR}/external/bzip2/)
+  find_library(BZIP2 bz2 PATHS ${CMAKE_BINARY_DIR}/external/bzip2)
 endif()
 
 ## Require c++14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,6 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/KMC
 
 ## Don't build the parts that we won't need
 set_target_properties(divsufsort PROPERTIES EXCLUDE_FROM_ALL 1)
-set_target_properties(gtest PROPERTIES EXCLUDE_FROM_ALL 1)
-set_target_properties(gtest_main PROPERTIES EXCLUDE_FROM_ALL 1)
-set_target_properties(bdbwt_tests PROPERTIES EXCLUDE_FROM_ALL 1)
 
 ## Set includes
 include_directories(${CMAKE_SOURCE_DIR}/BD_BWT_index/include ${CMAKE_SOURCE_DIR}/sdsl-lite/include ${CMAKE_SOURCE_DIR}/KMC/kmer_counter ${CMAKE_SOURCE_DIR}/KMC ${CMAKE_BINARY_DIR}/include)
@@ -112,15 +109,12 @@ include_directories(${CMAKE_SOURCE_DIR}/BD_BWT_index/include ${CMAKE_SOURCE_DIR}
 add_library(kmc_wrapper KMC_wrapper.cpp)
 add_executable(pseudoalign pseudoalign.cpp)
 add_executable(build_index build_index.cpp)
-add_executable(themisto_tests tests.cpp)
 
 ## Fix compilation order
 add_dependencies(kmc_wrapper kmc)
 add_dependencies(bdbwt sdsl divsufsort64)
-add_dependencies(bdbwt_tests sdsl divsufsort64)
 add_dependencies(pseudoalign kmc_wrapper bdbwt)
 add_dependencies(build_index kmc_wrapper bdbwt)
-add_dependencies(themisto_tests kmc_wrapper bdbwt)
 
 ## Handle compiling zlib or bzip2 from source
 if(CMAKE_BUILD_ZLIB)
@@ -138,4 +132,15 @@ endif()
 target_link_libraries(kmc_wrapper kmc Threads::Threads OpenMP::OpenMP_CXX ${BZIP2} ${ZLIB})
 target_link_libraries(pseudoalign kmc_wrapper bdbwt Threads::Threads OpenMP::OpenMP_CXX ${BZIP2} ${ZLIB})
 target_link_libraries(build_index kmc_wrapper bdbwt Threads::Threads OpenMP::OpenMP_CXX ${BZIP2} ${ZLIB})
-target_link_libraries(themisto_tests kmc_wrapper bdbwt Threads::Threads OpenMP::OpenMP_CXX ${BZIP2} ${ZLIB})
+
+## Build tests if doing a Debug build
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+  add_executable(themisto_tests tests.cpp)
+  add_dependencies(themisto_tests kmc_wrapper bdbwt)
+  add_dependencies(bdbwt_tests sdsl divsufsort64)
+  target_link_libraries(themisto_tests kmc_wrapper bdbwt Threads::Threads OpenMP::OpenMP_CXX ${BZIP2} ${ZLIB})
+else()
+  set_target_properties(bdbwt_tests PROPERTIES EXCLUDE_FROM_ALL 1)
+  set_target_properties(gtest PROPERTIES EXCLUDE_FROM_ALL 1)
+  set_target_properties(gtest_main PROPERTIES EXCLUDE_FROM_ALL 1)
+endif()


### PR DESCRIPTION
* Add zlib and bz2 headers to include path when compiling either from source. (Fixes #6)
* Build themisto_tests only when compiling Debug builds (Fixes #7, because the tests must be built with the debug flags for the asserts to work) 